### PR TITLE
ecdsa: reindex input data for the given signing parties

### DIFF
--- a/ecdsa/keygen/local_party_test.go
+++ b/ecdsa/keygen/local_party_test.go
@@ -136,7 +136,10 @@ func TestE2EConcurrentAndSaveFixtures(t *testing.T) {
 	// tss.SetCurve(elliptic.P256())
 
 	threshold := testThreshold
-	pIDs := tss.GenerateTestPartyIDs(testParticipants)
+	fixtures, pIDs, err := LoadKeygenTestFixtures(testParticipants)
+	if err != nil {
+		common.Logger.Info("No test fixtures were found, so the safe primes will be generated from scratch. This may take a while...")
+	}
 
 	p2pCtx := tss.NewPeerContext(pIDs)
 	parties := make([]*LocalParty, 0, len(pIDs))
@@ -150,10 +153,6 @@ func TestE2EConcurrentAndSaveFixtures(t *testing.T) {
 	startGR := runtime.NumGoroutine()
 
 	// init the parties
-	fixtures, err := LoadKeygenTestFixtures(len(pIDs))
-	if err != nil {
-		common.Logger.Info("No test fixtures were found, so the safe primes will be generated from scratch. This may take a while...")
-	}
 	for i := 0; i < len(pIDs); i++ {
 		var P *LocalParty
 		params := tss.NewParameters(p2pCtx, pIDs[i], len(pIDs), threshold)

--- a/ecdsa/keygen/save_data.go
+++ b/ecdsa/keygen/save_data.go
@@ -61,26 +61,26 @@ func (preParams LocalPreParams) Validate() bool {
 }
 
 // BuildLocalSaveDataSubset re-creates the LocalPartySaveData to contain data for only the list of signing parties.
-func BuildLocalSaveDataSubset(result LocalPartySaveData, sortedIDs tss.SortedPartyIDs) LocalPartySaveData {
-	keysToIndices := make(map[string]int, len(result.Ks))
-	for j, kj := range result.Ks {
+func BuildLocalSaveDataSubset(sourceData LocalPartySaveData, sortedIDs tss.SortedPartyIDs) LocalPartySaveData {
+	keysToIndices := make(map[string]int, len(sourceData.Ks))
+	for j, kj := range sourceData.Ks {
 		keysToIndices[hex.EncodeToString(kj.Bytes())] = j
 	}
-	newSaveData := NewLocalPartySaveData(sortedIDs.Len())
-	newSaveData.LocalPreParams = result.LocalPreParams
-	newSaveData.LocalSecrets = result.LocalSecrets
-	newSaveData.ECDSAPub = result.ECDSAPub
+	newData := NewLocalPartySaveData(sortedIDs.Len())
+	newData.LocalPreParams = sourceData.LocalPreParams
+	newData.LocalSecrets = sourceData.LocalSecrets
+	newData.ECDSAPub = sourceData.ECDSAPub
 	for j, id := range sortedIDs {
 		savedIdx, ok := keysToIndices[hex.EncodeToString(id.Key)]
 		if !ok {
 			common.Logger.Warning("BuildLocalSaveDataSubset: unable to find a signer party in the local save data", id)
 		}
-		newSaveData.Ks[j] = result.Ks[savedIdx]
-		newSaveData.NTildej[j] = result.NTildej[savedIdx]
-		newSaveData.H1j[j] = result.H1j[savedIdx]
-		newSaveData.H2j[j] = result.H2j[savedIdx]
-		newSaveData.BigXj[j] = result.BigXj[savedIdx]
-		newSaveData.PaillierPKs[j] = result.PaillierPKs[savedIdx]
+		newData.Ks[j] = sourceData.Ks[savedIdx]
+		newData.NTildej[j] = sourceData.NTildej[savedIdx]
+		newData.H1j[j] = sourceData.H1j[savedIdx]
+		newData.H2j[j] = sourceData.H2j[savedIdx]
+		newData.BigXj[j] = sourceData.BigXj[savedIdx]
+		newData.PaillierPKs[j] = sourceData.PaillierPKs[savedIdx]
 	}
-	return newSaveData
+	return newData
 }

--- a/ecdsa/keygen/save_data.go
+++ b/ecdsa/keygen/save_data.go
@@ -1,0 +1,86 @@
+// Copyright © 2019 Binance
+//
+// This file is part of Binance. The full Binance copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+package keygen
+
+import (
+	"encoding/hex"
+	"math/big"
+
+	"github.com/binance-chain/tss-lib/common"
+	"github.com/binance-chain/tss-lib/crypto"
+	"github.com/binance-chain/tss-lib/crypto/paillier"
+	"github.com/binance-chain/tss-lib/tss"
+)
+
+type (
+	LocalPreParams struct {
+		PaillierSK        *paillier.PrivateKey // ski
+		NTildei, H1i, H2i *big.Int             // n-tilde, h1, h2
+	}
+
+	LocalSecrets struct {
+		// secret fields (not shared, but stored locally)
+		Xi, ShareID *big.Int // xi, kj
+	}
+
+	// Everything in LocalPartySaveData is saved locally to user's HD when done
+	LocalPartySaveData struct {
+		LocalPreParams
+		LocalSecrets
+
+		// original indexes (ki in signing preparation phase)
+		Ks []*big.Int
+
+		// n-tilde, h1, h2 for range proofs
+		NTildej, H1j, H2j []*big.Int
+
+		// public keys (Xj = uj*G for each Pj)
+		BigXj       []*crypto.ECPoint     // Xj
+		PaillierPKs []*paillier.PublicKey // pkj
+
+		// used for test assertions (may be discarded)
+		ECDSAPub *crypto.ECPoint // y
+	}
+)
+
+func NewLocalPartySaveData(partyCount int) (saveData LocalPartySaveData) {
+	saveData.Ks = make([]*big.Int, partyCount)
+	saveData.NTildej = make([]*big.Int, partyCount)
+	saveData.H1j, saveData.H2j = make([]*big.Int, partyCount), make([]*big.Int, partyCount)
+	saveData.BigXj = make([]*crypto.ECPoint, partyCount)
+	saveData.PaillierPKs = make([]*paillier.PublicKey, partyCount)
+	return
+}
+
+func (preParams LocalPreParams) Validate() bool {
+	return preParams.PaillierSK != nil && preParams.NTildei != nil && preParams.H1i != nil && preParams.H2i != nil
+}
+
+// BuildLocalSaveDataSubset re-creates the LocalPartySaveData to contain data for only the list of signing parties.
+func BuildLocalSaveDataSubset(result LocalPartySaveData, sortedIDs tss.SortedPartyIDs) LocalPartySaveData {
+	keysToIndices := make(map[string]int, len(result.Ks))
+	for j, kj := range result.Ks {
+		keysToIndices[hex.EncodeToString(kj.Bytes())] = j
+	}
+	newSaveData := NewLocalPartySaveData(sortedIDs.Len())
+	newSaveData.LocalPreParams = result.LocalPreParams
+	newSaveData.LocalSecrets = result.LocalSecrets
+	newSaveData.ECDSAPub = result.ECDSAPub
+	for j, id := range sortedIDs {
+		savedIdx, ok := keysToIndices[hex.EncodeToString(id.Key)]
+		if !ok {
+			common.Logger.Warning("BuildLocalSaveDataSubset: unable to find a signer party in the local save data", id)
+		}
+		newSaveData.Ks[j] = result.Ks[savedIdx]
+		newSaveData.NTildej[j] = result.NTildej[savedIdx]
+		newSaveData.H1j[j] = result.H1j[savedIdx]
+		newSaveData.H2j[j] = result.H2j[savedIdx]
+		newSaveData.BigXj[j] = result.BigXj[savedIdx]
+		newSaveData.PaillierPKs[j] = result.PaillierPKs[savedIdx]
+	}
+	return newSaveData
+}

--- a/ecdsa/resharing/local_party.go
+++ b/ecdsa/resharing/local_party.go
@@ -70,11 +70,17 @@ func NewLocalParty(
 	out chan<- tss.Message,
 	end chan<- keygen.LocalPartySaveData,
 ) tss.Party {
+	subset := key
+	if params.IsOldCommittee() {
+		subset = keygen.BuildLocalSaveDataSubset(key, params.OldParties().IDs())
+	} else if params.IsNewCommittee() {
+		subset = key
+	}
 	p := &LocalParty{
 		BaseParty: new(tss.BaseParty),
 		params:    params,
 		temp:      localTempData{},
-		key:       key,
+		key:       subset,
 		out:       out,
 		end:       end,
 	}

--- a/ecdsa/resharing/local_party_test.go
+++ b/ecdsa/resharing/local_party_test.go
@@ -4,7 +4,7 @@
 // terms governing use, modification, and redistribution, is contained in the
 // file LICENSE at the root of the source code distribution tree.
 
-package resharing
+package resharing_test
 
 import (
 	"crypto/ecdsa"
@@ -20,6 +20,7 @@ import (
 	"github.com/binance-chain/tss-lib/common"
 	"github.com/binance-chain/tss-lib/crypto"
 	"github.com/binance-chain/tss-lib/ecdsa/keygen"
+	. "github.com/binance-chain/tss-lib/ecdsa/resharing"
 	"github.com/binance-chain/tss-lib/ecdsa/signing"
 	"github.com/binance-chain/tss-lib/test"
 	"github.com/binance-chain/tss-lib/tss"
@@ -50,7 +51,6 @@ func TestE2EConcurrent(t *testing.T) {
 
 	// PHASE: resharing
 	oldP2PCtx := tss.NewPeerContext(oldPIDs)
-
 	// init the new parties; re-use the fixture pre-params for speed
 	fixtures, _, err := keygen.LoadKeygenTestFixtures(testParticipants)
 	if err != nil {
@@ -159,7 +159,7 @@ func TestE2EConcurrent(t *testing.T) {
 signing:
 	// PHASE: signing
 	var signPIDs tss.SortedPartyIDs
-	keys, signPIDs, err = keygen.LoadKeygenTestFixtures(testThreshold + 1)
+	keys, signPIDs, err = keygen.LoadKeygenTestFixturesRandomSet(testThreshold+1, testParticipants)
 	assert.NoError(t, err)
 
 	signP2pCtx := tss.NewPeerContext(signPIDs)

--- a/ecdsa/resharing/round_5_new_step_3.go
+++ b/ecdsa/resharing/round_5_new_step_3.go
@@ -42,7 +42,7 @@ func (round *round5) Start() *tss.Error {
 			round.save.PaillierPKs[j] = r2msg1.UnmarshalPaillierPK()
 		}
 	} else if round.IsOldCommittee() {
-		round.save.Xi.SetInt64(0)
+		round.input.Xi.SetInt64(0)
 	}
 
 	round.end <- *round.save

--- a/ecdsa/resharing/rounds.go
+++ b/ecdsa/resharing/rounds.go
@@ -18,11 +18,11 @@ const (
 type (
 	base struct {
 		*tss.ReSharingParameters
-		save   *keygen.LocalPartySaveData
-		temp   *localTempData
-		out    chan<- tss.Message
-		end    chan<- keygen.LocalPartySaveData
-		oldOK, // old committee "ok" tracker
+		temp        *localTempData
+		input, save *keygen.LocalPartySaveData
+		out         chan<- tss.Message
+		end         chan<- keygen.LocalPartySaveData
+		oldOK,      // old committee "ok" tracker
 		newOK []bool // `ok` tracks parties which have been verified by Update(); this one is for the new committee
 		started bool
 		number  int

--- a/ecdsa/signing/local_party.go
+++ b/ecdsa/signing/local_party.go
@@ -96,7 +96,7 @@ type (
 func NewLocalParty(
 	msg *big.Int,
 	params *tss.Parameters,
-	keys keygen.LocalPartySaveData,
+	key keygen.LocalPartySaveData,
 	out chan<- tss.Message,
 	end chan<- SignatureData,
 ) tss.Party {
@@ -104,7 +104,7 @@ func NewLocalParty(
 	p := &LocalParty{
 		BaseParty: new(tss.BaseParty),
 		params:    params,
-		keys:      keys,
+		keys:      keygen.BuildLocalSaveDataSubset(key, params.Parties().IDs()),
 		temp:      localTempData{},
 		data:      SignatureData{},
 		out:       out,

--- a/ecdsa/signing/local_party_test.go
+++ b/ecdsa/signing/local_party_test.go
@@ -24,7 +24,8 @@ import (
 )
 
 const (
-	testThreshold = test.TestThreshold
+	testParticipants = test.TestParticipants
+	testThreshold    = test.TestThreshold
 )
 
 func setUp(level string) {
@@ -35,13 +36,13 @@ func setUp(level string) {
 
 func TestE2EConcurrent(t *testing.T) {
 	setUp("info")
-
 	threshold := testThreshold
 
 	// PHASE: load keygen fixtures
-	firstPartyIdx := 5
-	keys, signPIDs, err := keygen.LoadKeygenTestFixtures(testThreshold+1+firstPartyIdx, firstPartyIdx)
+	keys, signPIDs, err := keygen.LoadKeygenTestFixturesRandomSet(testThreshold+1, testParticipants)
 	assert.NoError(t, err, "should load keygen fixtures")
+	assert.Equal(t, testThreshold+1, len(keys))
+	assert.Equal(t, testThreshold+1, len(signPIDs))
 
 	// PHASE: signing
 	// use a shuffled selection of the list of parties for this test

--- a/ecdsa/signing/local_party_test.go
+++ b/ecdsa/signing/local_party_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 const (
-	testParticipants = test.TestParticipants
-	testThreshold    = test.TestThreshold
+	testThreshold = test.TestThreshold
 )
 
 func setUp(level string) {
@@ -38,15 +37,14 @@ func TestE2EConcurrent(t *testing.T) {
 	setUp("info")
 
 	threshold := testThreshold
-	pIDs := tss.GenerateTestPartyIDs(testParticipants)
 
 	// PHASE: load keygen fixtures
-	keys, err := keygen.LoadKeygenTestFixtures(testThreshold + 1)
+	firstPartyIdx := 5
+	keys, signPIDs, err := keygen.LoadKeygenTestFixtures(testThreshold+1+firstPartyIdx, firstPartyIdx)
 	assert.NoError(t, err, "should load keygen fixtures")
 
 	// PHASE: signing
-	signPIDs := pIDs[:threshold+1]
-
+	// use a shuffled selection of the list of parties for this test
 	p2pCtx := tss.NewPeerContext(signPIDs)
 	parties := make([]*LocalParty, 0, len(signPIDs))
 

--- a/ecdsa/signing/prepare.go
+++ b/ecdsa/signing/prepare.go
@@ -22,7 +22,7 @@ func PrepareForSigning(i, pax int, xi *big.Int, ks []*big.Int, bigXs []*crypto.E
 		panic(fmt.Errorf("indices and bigX are not same length"))
 	}
 	if len(ks) != pax {
-		panic(fmt.Errorf("indices is not in pax size"))
+		panic(fmt.Errorf("indices is not equal to the number of participants"))
 	}
 
 	// 2-4.

--- a/tss/party_id.go
+++ b/tss/party_id.go
@@ -41,7 +41,7 @@ func (mpid *MessageWrapper_PartyID) KeyInt() *big.Int {
 
 // NewPartyID constructs a new PartyID
 // Exported, used in `tss` client. `key` should remain consistent between runs for each party.
-func NewPartyID(id string, moniker string, key *big.Int) *PartyID {
+func NewPartyID(id, moniker string, key *big.Int) *PartyID {
 	return &PartyID{
 		MessageWrapper_PartyID: &MessageWrapper_PartyID{
 			Id:      id,


### PR DESCRIPTION
If the set of parties is not contiguous or does not begin from keygen index 0 when provided to the signing code, the save data must be re-indexed/filtered outside the lib to make signing work. 

This patch offers a workaround whereby the save data is temporarily re-built for the signing rounds to contain the expected ordered lists, removing the need for app-layer code to do that for a non-contiguous set of signers.
