### PR TITLE
ecdsa/keygen/*test: fix stall when generating new fixtures

### DIFF
--- a/ecdsa/keygen/local_party_test.go
+++ b/ecdsa/keygen/local_party_test.go
@@ -139,6 +139,7 @@ func TestE2EConcurrentAndSaveFixtures(t *testing.T) {
 	fixtures, pIDs, err := LoadKeygenTestFixtures(testParticipants)
 	if err != nil {
 		common.Logger.Info("No test fixtures were found, so the safe primes will be generated from scratch. This may take a while...")
+		pIDs = tss.GenerateTestPartyIDs(testParticipants)
 	}
 
 	p2pCtx := tss.NewPeerContext(pIDs)


### PR DESCRIPTION
When the fixture files were deleted this test was stalling, waiting on an empty set of parties.
