### PR TITLE
style: refactor crypto lib to consistent verification style

### DIFF
--- a/crypto/commitments/commitment.go
+++ b/crypto/commitments/commitment.go
@@ -58,11 +58,7 @@ func (cmt *HashCommitDecommit) Verify() bool {
 		return false
 	}
 	hash := common.SHA512_256i(D...)
-	if hash.Cmp(C) == 0 {
-		return true
-	} else {
-		return false
-	}
+	return hash.Cmp(C) == 0
 }
 
 func (cmt *HashCommitDecommit) DeCommit() (bool, HashDeCommitment) {

--- a/crypto/schnorr/schnorr_proof.go
+++ b/crypto/schnorr/schnorr_proof.go
@@ -70,10 +70,7 @@ func (pf *ZKProof) Verify(X *crypto.ECPoint) bool {
 	if err != nil {
 		return false
 	}
-	if aXc.X().Cmp(tG.X()) != 0 || aXc.Y().Cmp(tG.Y()) != 0 {
-		return false
-	}
-	return true
+	return aXc.X().Cmp(tG.X()) == 0 && aXc.Y().Cmp(tG.Y()) == 0
 }
 
 func (pf *ZKProof) ValidateBasic() bool {
@@ -128,10 +125,7 @@ func (pf *ZKVProof) Verify(V, R *crypto.ECPoint) bool {
 	if err != nil {
 		return false
 	}
-	if tRuG.X().Cmp(aVc.X()) != 0 || tRuG.Y().Cmp(aVc.Y()) != 0 {
-		return false
-	}
-	return true
+	return tRuG.X().Cmp(aVc.X()) == 0 && tRuG.Y().Cmp(aVc.Y()) == 0
 }
 
 func (pf *ZKVProof) ValidateBasic() bool {


### PR DESCRIPTION
in vss::Share::Verify & mta::ProofBob::Verify & all other  ValidateBasic()/Validate(), boolean computations are returned directly. 
+ https://github.com/binance-chain/tss-lib/blob/e860e36eaaa63afcaf1e5a0ed79b6f56362e88c8/crypto/vss/feldman_vss.go#L93
+ https://github.com/binance-chain/tss-lib/blob/e860e36eaaa63afcaf1e5a0ed79b6f56362e88c8/crypto/mta/proofs.go#L276
+ https://github.com/binance-chain/tss-lib/blob/e860e36eaaa63afcaf1e5a0ed79b6f56362e88c8/crypto/mta/proofs.go#L279
+ https://github.com/binance-chain/tss-lib/blob/e860e36eaaa63afcaf1e5a0ed79b6f56362e88c8/crypto/ecpoint.go#L76
+ ...

However, this is not the case in commitment and schnorr_proof package. 

This PR refactor them to consistent verification style, and **may save condition branch executions if being compiled without optimization**.