### PR TITLE
fix: reshare for eddsa panic if old committee exceed t+1

### DIFF
--- a/eddsa/resharing/round_1_old_step_1.go
+++ b/eddsa/resharing/round_1_old_step_1.go
@@ -43,7 +43,7 @@ func (round *round1) Start() *tss.Error {
 	// 1. PrepareForSigning() -> w_i
 	xi, ks := round.input.Xi, round.input.Ks
 	newKs := round.NewParties().IDs().Keys()
-	wi := signing.PrepareForSigning(i, round.Threshold()+1, xi, ks)
+	wi := signing.PrepareForSigning(i, len(round.OldParties().IDs()), xi, ks)
 
 	// 2.
 	vi, shares, err := vss.Create(round.NewThreshold(), wi, newKs)

--- a/eddsa/signing/prepare.go
+++ b/eddsa/signing/prepare.go
@@ -18,7 +18,10 @@ import (
 func PrepareForSigning(i, pax int, xi *big.Int, ks []*big.Int) (wi *big.Int) {
 	modQ := common.ModInt(tss.EC().Params().N)
 	if len(ks) != pax {
-		panic(fmt.Errorf("indices is not in pax size"))
+		panic(fmt.Errorf("PrepareForSigning: len(ks) != pax (%d != %d)", len(ks), pax))
+	}
+	if len(ks) <= i {
+		panic(fmt.Errorf("PrepareForSigning: len(ks) <= i (%d <= %d)", len(ks), i))
 	}
 
 	// 1-4.


### PR DESCRIPTION
fix eddsa reshare panic when old committee number exceed t+1