### PR TITLE
fix R and S may not be 32 bytes

### DIFF
--- a/ecdsa/signing/finalize.go
+++ b/ecdsa/signing/finalize.go
@@ -56,10 +56,10 @@ func (round *finalization) Start() *tss.Error {
 	}
 
 	// save the signature for final output
-	round.data.Signature = append(round.temp.rx.Bytes(), sumS.Bytes()...)
+	round.data.R = fillTo32BytesInPlace(round.temp.rx.Bytes())
+	round.data.S = fillTo32BytesInPlace(sumS.Bytes())
+	round.data.Signature = append(round.data.R, round.data.S...)
 	round.data.SignatureRecovery = []byte{byte(recid)}
-	round.data.R = round.temp.rx.Bytes()
-	round.data.S = sumS.Bytes()
 	round.data.M = round.temp.m.Bytes()
 
 	pk := ecdsa.PublicKey{
@@ -89,4 +89,14 @@ func (round *finalization) Update() (bool, *tss.Error) {
 
 func (round *finalization) NextRound() tss.Round {
 	return nil // finished!
+}
+
+func fillTo32BytesInPlace(src []byte) []byte {
+	oriLen := len(src)
+	if oriLen < 32 {
+		for i := 0; i < 32-oriLen; i++ {
+			src = append([]byte{0}, src...)
+		}
+	}
+	return src
 }

--- a/ecdsa/signing/finalize.go
+++ b/ecdsa/signing/finalize.go
@@ -56,8 +56,9 @@ func (round *finalization) Start() *tss.Error {
 	}
 
 	// save the signature for final output
-	round.data.R = fillTo32BytesInPlace(round.temp.rx.Bytes())
-	round.data.S = fillTo32BytesInPlace(sumS.Bytes())
+	bitSizeInBytes := tss.EC().Params().BitSize / 8
+	round.data.R = padToLengthBytesInPlace(round.temp.rx.Bytes(), bitSizeInBytes)
+	round.data.S = padToLengthBytesInPlace(sumS.Bytes(), bitSizeInBytes)
 	round.data.Signature = append(round.data.R, round.data.S...)
 	round.data.SignatureRecovery = []byte{byte(recid)}
 	round.data.M = round.temp.m.Bytes()
@@ -91,10 +92,10 @@ func (round *finalization) NextRound() tss.Round {
 	return nil // finished!
 }
 
-func fillTo32BytesInPlace(src []byte) []byte {
+func padToLengthBytesInPlace(src []byte, length int) []byte {
 	oriLen := len(src)
-	if oriLen < 32 {
-		for i := 0; i < 32-oriLen; i++ {
+	if oriLen < length {
+		for i := 0; i < length-oriLen; i++ {
 			src = append([]byte{0}, src...)
 		}
 	}

--- a/ecdsa/signing/local_party_test.go
+++ b/ecdsa/signing/local_party_test.go
@@ -132,7 +132,7 @@ signing:
 
 func TestFillTo32BytesInPlace(t *testing.T) {
 	s := big.NewInt(123456789)
-	normalizedS := fillTo32BytesInPlace(s.Bytes())
+	normalizedS := padToLengthBytesInPlace(s.Bytes(), 32)
 	assert.True(t, big.NewInt(0).SetBytes(normalizedS).Cmp(s) == 0)
 	assert.Equal(t, 32, len(normalizedS))
 	assert.NotEqual(t, 32, len(s.Bytes()))

--- a/ecdsa/signing/local_party_test.go
+++ b/ecdsa/signing/local_party_test.go
@@ -129,3 +129,11 @@ signing:
 		}
 	}
 }
+
+func TestFillTo32BytesInPlace(t *testing.T) {
+	s := big.NewInt(123456789)
+	normalizedS := fillTo32BytesInPlace(s.Bytes())
+	assert.True(t, big.NewInt(0).SetBytes(normalizedS).Cmp(s) == 0)
+	assert.Equal(t, 32, len(normalizedS))
+	assert.NotEqual(t, 32, len(s.Bytes()))
+}


### PR DESCRIPTION
The R and S might not be less than 32 bytes, if we return such R and S and the client code concatenates these two bytes together, the signature would not be 64 bytes. Such signature would fail for blockchains (for example Ethereum) that check the signature length: https://github.com/ethereum/go-ethereum/blob/master/crypto/secp256k1/secp256.go#L169-L171