### PR TITLE
Cherrypick child key derivation

### DIFF
--- a/crypto/ckd/child_key_derivation.go
+++ b/crypto/ckd/child_key_derivation.go
@@ -1,0 +1,140 @@
+// Copyright © Swingby
+
+package ckd
+
+import (
+	"crypto/ecdsa"
+	"crypto/hmac"
+	"crypto/sha512"
+	"encoding/binary"
+	"errors"
+	"math/big"
+
+	"github.com/binance-chain/tss-lib/common"
+	"github.com/binance-chain/tss-lib/crypto"
+	"github.com/binance-chain/tss-lib/tss"
+)
+
+type ExtendedKey struct {
+	ecdsa.PublicKey
+	Depth      byte
+	ChildIndex uint32
+	ChainCode  []byte // 32 bytes
+}
+
+// For more information about child key derivation see https://github.com/binance-chain/tss-lib/issues/104
+// https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki .
+// The functions below do not implement the full BIP-32 specification. As mentioned in the Jira ticket above,
+// we only use non-hardened derived keys.
+
+const (
+
+	// HardenedKeyStart hardened key starts.
+	HardenedKeyStart = 0x80000000 // 2^31
+
+	// max Depth
+	maxDepth = 0xFF
+
+	PubKeyBytesLenCompressed = 33
+
+	pubKeyCompressed byte = 0x2
+)
+
+func isOdd(a *big.Int) bool {
+	return a.Bit(0) == 1
+}
+
+// PaddedAppend append src to dst, if less than size padding 0 at start
+func paddedAppend(dst []byte, srcPaddedSize int, src []byte) []byte {
+	return append(dst, paddedBytes(srcPaddedSize, src)...)
+}
+
+// PaddedBytes padding byte array to size length
+func paddedBytes(size int, src []byte) []byte {
+	offset := size - len(src)
+	tmp := src
+	if offset > 0 {
+		tmp = make([]byte, size)
+		copy(tmp[offset:], src)
+	}
+	return tmp
+}
+
+// SerializeCompressed serializes a public key 33-byte compressed format
+func serializeCompressed(publicKeyX *big.Int, publicKeyY *big.Int) []byte {
+	b := make([]byte, 0, PubKeyBytesLenCompressed)
+	format := pubKeyCompressed
+	if isOdd(publicKeyY) {
+		format |= 0x1
+	}
+	b = append(b, format)
+	return paddedAppend(b, 32, publicKeyX.Bytes())
+}
+
+func DeriveChildKeyFromHierarchy(indicesHierarchy []uint32, pk *ExtendedKey, mod *big.Int) (*big.Int, *ExtendedKey, error) {
+	var k = pk
+	var err error
+	var childKey *ExtendedKey
+	mod_ := common.ModInt(mod)
+	ilNum := big.NewInt(0)
+	for index := range indicesHierarchy {
+		ilNumOld := ilNum
+		ilNum, childKey, err = DeriveChildKey(indicesHierarchy[index], k)
+		if err != nil {
+			return nil, nil, err
+		}
+		k = childKey
+		ilNum = mod_.Add(ilNum, ilNumOld)
+	}
+	return ilNum, k, nil
+}
+
+// Derive a child key from the given parent key. The function returns "IL" ("I left"), per BIP-32 spec. It also
+// returns the derived child key.
+func DeriveChildKey(index uint32, pk *ExtendedKey) (*big.Int, *ExtendedKey, error) {
+	if index >= HardenedKeyStart {
+		return nil, nil, errors.New("the index must be non-hardened")
+	}
+	if pk.Depth == maxDepth {
+		return nil, nil, errors.New("cannot derive key beyond max depth")
+	}
+
+	cryptoPk, err := crypto.NewECPoint(tss.EC(), pk.X, pk.Y)
+
+	data := make([]byte, 37)
+	copy(data, serializeCompressed(pk.X, pk.Y))
+	binary.BigEndian.PutUint32(data[33:], index)
+
+	// I = HMAC-SHA512(Key = chainCode, Data=data)
+	hmac512 := hmac.New(sha512.New, pk.ChainCode)
+	hmac512.Write(data)
+	ilr := hmac512.Sum(nil)
+	il := ilr[:32]
+	childChainCode := ilr[32:]
+	ilNum := new(big.Int).SetBytes(il)
+
+	if ilNum.Cmp(tss.EC().Params().N) >= 0  || ilNum.Sign() == 0 {
+		// falling outside of the valid range for curve private keys
+		err = errors.New("invalid derived key")
+		common.Logger.Error("error deriving child key")
+		return nil, nil, err
+	}
+
+	deltaG := crypto.ScalarBaseMult(tss.EC(), ilNum)
+	if err != nil {
+		common.Logger.Error("error computing delta G")
+		return nil, nil, err
+	}
+	childCryptoPk, err := cryptoPk.Add(deltaG)
+	if err != nil {
+		common.Logger.Error("error adding delta G to parent key")
+		return nil, nil, err
+	}
+	childPk := &ExtendedKey{
+		PublicKey:  *childCryptoPk.ToECDSAPubKey(),
+		Depth:      pk.Depth + 1,
+		ChildIndex: index,
+		ChainCode:  childChainCode,
+	}
+	return ilNum, childPk, nil
+}

--- a/crypto/ecpoint.go
+++ b/crypto/ecpoint.go
@@ -8,6 +8,7 @@ package crypto
 
 import (
 	"bytes"
+	"crypto/ecdsa"
 	"crypto/elliptic"
 	"encoding/binary"
 	"encoding/json"
@@ -55,6 +56,14 @@ func (p *ECPoint) ScalarMult(k *big.Int) *ECPoint {
 	x, y := p.curve.ScalarMult(p.X(), p.Y(), k.Bytes())
 	newP, _ := NewECPoint(p.curve, x, y) // it must be on the curve, no need to check.
 	return newP
+}
+
+func (p *ECPoint) ToECDSAPubKey() *ecdsa.PublicKey {
+	return &ecdsa.PublicKey{
+		Curve: p.curve,
+		X:     p.X(),
+		Y:     p.Y(),
+	}
 }
 
 func (p *ECPoint) IsOnCurve() bool {

--- a/ecdsa/resharing/local_party_test.go
+++ b/ecdsa/resharing/local_party_test.go
@@ -172,7 +172,7 @@ signing:
 
 	for j, signPID := range signPIDs {
 		params := tss.NewParameters(tss.S256(), signP2pCtx, signPID, len(signPIDs), newThreshold)
-		P := signing.NewLocalParty(big.NewInt(42), params, signKeys[j], signOutCh, signEndCh).(*signing.LocalParty)
+		P := signing.NewLocalParty(big.NewInt(42), params, signKeys[j], big.NewInt(0), signOutCh, signEndCh).(*signing.LocalParty)
 		signParties = append(signParties, P)
 		go func(P *signing.LocalParty) {
 			if err := P.Start(); err != nil {

--- a/ecdsa/signing/key_derivation_util.go
+++ b/ecdsa/signing/key_derivation_util.go
@@ -1,0 +1,57 @@
+// Copyright © 2021 Swingby
+
+package signing
+
+import (
+	"crypto/ecdsa"
+	"math/big"
+
+	"github.com/binance-chain/tss-lib/common"
+	"github.com/binance-chain/tss-lib/crypto"
+	"github.com/binance-chain/tss-lib/crypto/ckd"
+	"github.com/binance-chain/tss-lib/ecdsa/keygen"
+	"github.com/binance-chain/tss-lib/tss"
+)
+
+func UpdatePublicKeyAndAdjustBigXj(keyDerivationDelta *big.Int, keys []keygen.LocalPartySaveData,
+	extendedChildPk *ecdsa.PublicKey) error {
+	var err error
+	gDelta := crypto.ScalarBaseMult(tss.EC(), keyDerivationDelta)
+	for k := range keys {
+		keys[k].ECDSAPub, err = crypto.NewECPoint(tss.EC(), extendedChildPk.X, extendedChildPk.Y)
+		if err != nil {
+			common.Logger.Errorf("error creating new extended child public key")
+			return err
+		}
+		// Suppose X_j has shamir shares X_j0,     X_j1,     ..., X_jn
+		// So X_j + D has shamir shares  X_j0 + D, X_j1 + D, ..., X_jn + D
+		for j := range keys[k].BigXj {
+			keys[k].BigXj[j], err = keys[k].BigXj[j].Add(gDelta)
+			if err != nil {
+				common.Logger.Errorf("error in delta operation")
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func derivingPubkeyFromPath(masterPub *crypto.ECPoint, 
+							chainCode []byte, 
+							path []uint32) (*big.Int, *ckd.ExtendedKey, error) {
+	// build ecdsa key pair
+	pk := ecdsa.PublicKey{
+		Curve: tss.EC(),
+		X:     masterPub.X(),
+		Y:     masterPub.Y(),
+	}
+
+	extendedParentPk := &ckd.ExtendedKey{
+		PublicKey:  pk,
+		Depth:      0,
+		ChildIndex: 0,
+		ChainCode:  chainCode[:],
+	}
+
+	return ckd.DeriveChildKeyFromHierarchy(path, extendedParentPk, tss.EC().Params().N)
+}

--- a/ecdsa/signing/local_party.go
+++ b/ecdsa/signing/local_party.go
@@ -61,6 +61,7 @@ type (
 		theta,
 		thetaInverse,
 		sigma,
+		keyDerivationDelta,
 		gamma *big.Int
 		cis        []*big.Int
 		bigWs      []*crypto.ECPoint
@@ -97,6 +98,7 @@ func NewLocalParty(
 	msg *big.Int,
 	params *tss.Parameters,
 	key keygen.LocalPartySaveData,
+	keyDerivationDelta *big.Int,
 	out chan<- tss.Message,
 	end chan<- common.SignatureData,
 ) tss.Party {
@@ -122,6 +124,7 @@ func NewLocalParty(
 	p.temp.signRound8Messages = make([]tss.ParsedMessage, partyCount)
 	p.temp.signRound9Messages = make([]tss.ParsedMessage, partyCount)
 	// temp data init
+	p.temp.keyDerivationDelta = keyDerivationDelta
 	p.temp.m = msg
 	p.temp.cis = make([]*big.Int, partyCount)
 	p.temp.bigWs = make([]*crypto.ECPoint, partyCount)

--- a/ecdsa/signing/local_party_test.go
+++ b/ecdsa/signing/local_party_test.go
@@ -59,7 +59,8 @@ func TestE2EConcurrent(t *testing.T) {
 	for i := 0; i < len(signPIDs); i++ {
 		params := tss.NewParameters(tss.S256(), p2pCtx, signPIDs[i], len(signPIDs), threshold)
 
-		P := NewLocalParty(big.NewInt(42), params, keys[i], outCh, endCh).(*LocalParty)
+		keyDerivationDelta := big.NewInt(0)
+		P := NewLocalParty(big.NewInt(42), params, keys[i], keyDerivationDelta, outCh, endCh).(*LocalParty)
 		parties = append(parties, P)
 		go func(P *LocalParty) {
 			if err := P.Start(); err != nil {
@@ -72,6 +73,114 @@ func TestE2EConcurrent(t *testing.T) {
 signing:
 	for {
 		fmt.Printf("ACTIVE GOROUTINES: %d\n", runtime.NumGoroutine())
+		select {
+		case err := <-errCh:
+			common.Logger.Errorf("Error: %s", err)
+			assert.FailNow(t, err.Error())
+			break signing
+
+		case msg := <-outCh:
+			dest := msg.GetTo()
+			if dest == nil {
+				for _, P := range parties {
+					if P.PartyID().Index == msg.GetFrom().Index {
+						continue
+					}
+					go updater(P, msg, errCh)
+				}
+			} else {
+				if dest[0].Index == msg.GetFrom().Index {
+					t.Fatalf("party %d tried to send a message to itself (%d)", dest[0].Index, msg.GetFrom().Index)
+				}
+				go updater(parties[dest[0].Index], msg, errCh)
+			}
+
+		case <-endCh:
+			atomic.AddInt32(&ended, 1)
+			if atomic.LoadInt32(&ended) == int32(len(signPIDs)) {
+				t.Logf("Done. Received signature data from %d participants", ended)
+				R := parties[0].temp.bigR
+				r := parties[0].temp.rx
+				fmt.Printf("sign result: R(%s, %s), r=%s\n", R.X().String(), R.Y().String(), r.String())
+
+				modN := common.ModInt(tss.S256().Params().N)
+
+				// BEGIN check s correctness
+				sumS := big.NewInt(0)
+				for _, p := range parties {
+					sumS = modN.Add(sumS, p.temp.si)
+				}
+				fmt.Printf("S: %s\n", sumS.String())
+				// END check s correctness
+
+				// BEGIN ECDSA verify
+				pkX, pkY := keys[0].ECDSAPub.X(), keys[0].ECDSAPub.Y()
+				pk := ecdsa.PublicKey{
+					Curve: tss.EC(),
+					X:     pkX,
+					Y:     pkY,
+				}
+				ok := ecdsa.Verify(&pk, big.NewInt(42).Bytes(), R.X(), sumS)
+				assert.True(t, ok, "ecdsa verify must pass")
+				t.Log("ECDSA signing test done.")
+				// END ECDSA verify
+
+				break signing
+			}
+		}
+	}
+}
+
+func TestE2EWithHDKeyDerivation(t *testing.T) {
+	setUp("info")
+	threshold := testThreshold
+
+	// PHASE: load keygen fixtures
+	keys, signPIDs, err := keygen.LoadKeygenTestFixturesRandomSet(testThreshold+1, testParticipants)
+	assert.NoError(t, err, "should load keygen fixtures")
+	assert.Equal(t, testThreshold+1, len(keys))
+	assert.Equal(t, testThreshold+1, len(signPIDs))
+
+	chainCode := make([]byte, 32)
+	max32b := new(big.Int).Lsh(new(big.Int).SetUint64(1), 256)
+	max32b = new(big.Int).Sub(max32b, new(big.Int).SetUint64(1))
+	common.GetRandomPositiveInt(max32b).FillBytes(chainCode)
+
+	il, extendedChildPk, errorDerivation := derivingPubkeyFromPath(keys[0].ECDSAPub, chainCode, []uint32{12, 209, 3})
+	assert.NoErrorf(t, errorDerivation, "there should not be an error deriving the child public key")
+
+	keyDerivationDelta := il
+
+	err = UpdatePublicKeyAndAdjustBigXj(keyDerivationDelta, keys, &extendedChildPk.PublicKey)
+	assert.NoErrorf(t, err, "there should not be an error setting the derived keys")
+
+	// PHASE: signing
+	// use a shuffled selection of the list of parties for this test
+	p2pCtx := tss.NewPeerContext(signPIDs)
+	parties := make([]*LocalParty, 0, len(signPIDs))
+
+	errCh := make(chan *tss.Error, len(signPIDs))
+	outCh := make(chan tss.Message, len(signPIDs))
+	endCh := make(chan common.SignatureData, len(signPIDs))
+
+	updater := test.SharedPartyUpdater
+
+	// init the parties
+	for i := 0; i < len(signPIDs); i++ {
+		params := tss.NewParameters(tss.S256(), p2pCtx, signPIDs[i], len(signPIDs), threshold)
+		
+		P := NewLocalParty(big.NewInt(42), params, keys[i], keyDerivationDelta, outCh, endCh).(*LocalParty)
+		parties = append(parties, P)
+		go func(P *LocalParty) {
+			if err := P.Start(); err != nil {
+				errCh <- err
+			}
+		}(P)
+	}
+
+	var ended int32
+signing:
+	for {
 		select {
 		case err := <-errCh:
 			common.Logger.Errorf("Error: %s", err)

--- a/ecdsa/signing/round_1.go
+++ b/ecdsa/signing/round_1.go
@@ -121,6 +121,13 @@ func (round *round1) prepare() error {
 	ks := round.key.Ks
 	bigXs := round.key.BigXj
 
+	// adding the key derivation delta to the xi's
+	// Suppose x has shamir shares x_0,     x_1,     ..., x_n
+	// So x + D has shamir shares  x_0 + D, x_1 + D, ..., x_n + D
+	mod := common.ModInt(tss.EC().Params().N)
+	xi = mod.Add(round.temp.keyDerivationDelta, xi)
+	round.key.Xi = xi
+
 	if round.Threshold()+1 > len(ks) {
 		return fmt.Errorf("t+1=%d is not satisfied by the key count of %d", round.Threshold()+1, len(ks))
 	}


### PR DESCRIPTION
The original implementation is in
https://github.com/SwingbyProtocol/tss-lib/pull/6/files#diff-e663957d1112b8c89bb7a782fe1cebe0d5e4d84a17861ae5af5cc0b59d1dbf56
Some changes made according to audit report