### PR TITLE
Do not normalize IDs of Shamir's Secret Sharing

### DIFF
--- a/crypto/vss/feldman_vss.go
+++ b/crypto/vss/feldman_vss.go
@@ -42,7 +42,7 @@ var (
 // Check share ids of Shamir's Secret Sharing, return error if duplicate or 0 value found
 func CheckIndexes(ec elliptic.Curve, indexes []*big.Int) ([]*big.Int, error) {
 	visited := make(map[string]struct{})
-	for i, v := range indexes {
+	for _, v := range indexes {
 		vMod := new(big.Int).Mod(v, ec.Params().N)
 		if vMod.Cmp(zero) == 0 {
 			return nil, errors.New("party index should not be 0")
@@ -52,7 +52,6 @@ func CheckIndexes(ec elliptic.Curve, indexes []*big.Int) ([]*big.Int, error) {
 			return nil, fmt.Errorf("duplicate indexes %s", vModStr)
 		}
 		visited[vModStr] = struct{}{}
-		indexes[i] = vMod
 	}
 	return indexes, nil
 }


### PR DESCRIPTION
We need to ensure that:
- all indexes are non-zero,
- all indexes are non-zero modulo the curve order,
- all indexes are unique modulo the curve order.

The first two are guarded in `CheckIndexes` function by:

```
vMod := new(big.Int).Mod(v, ec.Params().N)
if vMod.Cmp(zero) == 0 {
return nil, errors.New("party index should not be 0")
}
```

The last one is guarded by:
```
vModStr := vMod.String()
if _, ok := visited[vModStr]; ok {
return nil, fmt.Errorf("duplicate indexes %s", vModStr)
}
visited[vModStr] = struct{}{}
```

`CheckIndexes` was additionally normalizing identifiers mod elliptic curve order.
This was not really needed and could cause problems during signing.