### PR TITLE
Additional check when Ks mismatch in savedata and sortedID

### DIFF
--- a/ecdsa/keygen/save_data.go
+++ b/ecdsa/keygen/save_data.go
@@ -8,9 +8,9 @@ package keygen
 
 import (
 	"encoding/hex"
+	"errors"
 	"math/big"
 
-	"github.com/binance-chain/tss-lib/common"
 	"github.com/binance-chain/tss-lib/crypto"
 	"github.com/binance-chain/tss-lib/crypto/paillier"
 	"github.com/binance-chain/tss-lib/tss"
@@ -87,7 +87,7 @@ func BuildLocalSaveDataSubset(sourceData LocalPartySaveData, sortedIDs tss.Sorte
 	for j, id := range sortedIDs {
 		savedIdx, ok := keysToIndices[hex.EncodeToString(id.Key)]
 		if !ok {
-			common.Logger.Warning("BuildLocalSaveDataSubset: unable to find a signer party in the local save data", id)
+			panic(errors.New("BuildLocalSaveDataSubset: unable to find a signer party in the local save data"))
 		}
 		newData.Ks[j] = sourceData.Ks[savedIdx]
 		newData.NTildej[j] = sourceData.NTildej[savedIdx]

--- a/ecdsa/signing/prepare.go
+++ b/ecdsa/signing/prepare.go
@@ -34,8 +34,13 @@ func PrepareForSigning(ec elliptic.Curve, i, pax int, xi *big.Int, ks []*big.Int
 		if j == i {
 			continue
 		}
+		ksj := ks[j]
+		ksi := ks[i]
+		if ksj.Cmp(ksi) == 0 {
+			panic(fmt.Errorf("index of two parties are equal"))
+		}
 		// big.Int Div is calculated as: a/b = a * modInv(b,q)
-		coef := modQ.Mul(ks[j], modQ.ModInverse(new(big.Int).Sub(ks[j], ks[i])))
+		coef := modQ.Mul(ks[j], modQ.ModInverse(new(big.Int).Sub(ksj, ksi)))
 		wi = modQ.Mul(wi, coef)
 	}
 

--- a/eddsa/keygen/save_data.go
+++ b/eddsa/keygen/save_data.go
@@ -10,7 +10,6 @@ import (
 	"encoding/hex"
 	"math/big"
 
-	"github.com/binance-chain/tss-lib/common"
 	"github.com/binance-chain/tss-lib/crypto"
 	"github.com/binance-chain/tss-lib/tss"
 )
@@ -54,7 +53,7 @@ func BuildLocalSaveDataSubset(sourceData LocalPartySaveData, sortedIDs tss.Sorte
 	for j, id := range sortedIDs {
 		savedIdx, ok := keysToIndices[hex.EncodeToString(id.Key)]
 		if !ok {
-			common.Logger.Warning("BuildLocalSaveDataSubset: unable to find a signer party in the local save data", id)
+			panic("BuildLocalSaveDataSubset: unable to find a signer party in the local save data")
 		}
 		newData.Ks[j] = sourceData.Ks[savedIdx]
 		newData.BigXj[j] = sourceData.BigXj[savedIdx]

--- a/eddsa/signing/prepare.go
+++ b/eddsa/signing/prepare.go
@@ -30,8 +30,13 @@ func PrepareForSigning(ec elliptic.Curve, i, pax int, xi *big.Int, ks []*big.Int
 		if j == i {
 			continue
 		}
+		ksj := ks[j]
+		ksi := ks[i]
+		if ksj.Cmp(ksi) == 0 {
+			panic(fmt.Errorf("index of two parties are equal"))
+		}
 		// big.Int Div is calculated as: a/b = a * modInv(b,q)
-		coef := modQ.Mul(ks[j], modQ.ModInverse(new(big.Int).Sub(ks[j], ks[i])))
+		coef := modQ.Mul(ks[j], modQ.ModInverse(new(big.Int).Sub(ksj, ksi)))
 		wi = modQ.Mul(wi, coef)
 	}
 


### PR DESCRIPTION
Following reply on vss fix that adding defense when Ks mismatch