### PR TITLE
Fix for ECDSA keygen test

### DIFF
--- a/ecdsa/keygen/local_party_test.go
+++ b/ecdsa/keygen/local_party_test.go
@@ -249,10 +249,7 @@ keygen:
 				u := new(big.Int)
 				for j, Pj := range parties {
 					pShares := make(vss.Shares, 0)
-					for j2, P := range parties {
-						if j2 == j {
-							continue
-						}
+					for _, P := range parties {
 						vssMsgs := P.temp.kgRound2Message1s
 						share := vssMsgs[j].Content().(*KGRound2Message1).Share
 						shareStruct := &vss.Share{

--- a/ecdsa/keygen/round_2.go
+++ b/ecdsa/keygen/round_2.go
@@ -105,7 +105,6 @@ func (round *round2) Start() *tss.Error {
 			round.temp.kgRound2Message1s[j] = r2msg1
 			continue
 		}
-		round.temp.kgRound2Message1s[i] = r2msg1
 		round.out <- r2msg1
 	}
 


### PR DESCRIPTION
In the test, shares is collected excluding Pj's own share. It causes problem in like 2/1 threshold setting, for omitting own share will result in no enough threshold+1 shares can be collected